### PR TITLE
Specify Serenity version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 [dependencies]
 dotenv = "0.15.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-serenity = { default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
+serenity = { version = "0.10", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 chrono = "0.4.10"


### PR DESCRIPTION
Your repo makes a nice little starting template.

This uses the latest version of Serenity and locks the minor version prevent future incompatible.